### PR TITLE
Utilize lexer hack for disambiguation

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/Template.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/Template.sv
@@ -8,6 +8,8 @@ imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack as lh;
 imports edu:umn:cs:melt:ableC:abstractsyntax as ast;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction as ast;
 
+imports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack as lh;
+
 exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:templateStructForwardDecl;
 exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:templateStructDecl;
 exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:templateFunctionDecl;
@@ -15,13 +17,24 @@ exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:usingDecl;
 exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:instantiationTypeExpr;
 exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:instantiationExpr;
 
--- Doesn't really belong in any spesific subgrammar, only conflicts when composing
--- instantiationExpr and instantiationTypeExpr
-disambiguate TemplateIdentifier_t, TemplateTypeName_t
+{- Disambiguate between template identifiers, template type names, regular
+ - identifiers, and regular type names.
+ - This is a simple extension to the host lexer hack mechanism for
+ - disambiguating regular identifiers and type names.
+ - We need to write a seperate function for every group where an amiguity exists.
+ - This function is placed at the top-level since this conflict only shows up in
+ - the composition of instantiationExpr and instantiationTypeExpr, the other
+ - functions are in these respective sub-grammars.
+ -}
+disambiguate TemplateIdentifier_t, TemplateTypeName_t, Identifier_t, TypeName_t
 {
   pluck
-    case lookupBy(stringEq, substring(0, length(lexeme) - 1, lexeme), head(context)) of
-    | just(lh:typenameType_c()) -> TemplateTypeName_t
-    | _ -> TemplateIdentifier_t
+    case lookupBy(stringEq, lexeme, head(context)) of
+    | just(lh:templateIdentType_c()) -> TemplateIdentifier_t
+    | just(lh:templateTypenameType_c()) -> TemplateTypeName_t
+    | just(lh:identType_c()) -> Identifier_t
+    | just(lh:typenameType_c()) -> TypeName_t
+    | nothing() -> Identifier_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for TemplateIdentifier_t, TemplateTypeName_t, Identifier_t, TypeName_t: ${hackUnparse(it)}")
     end;
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/instantiationExpr/Instantiation.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/instantiationExpr/Instantiation.sv
@@ -4,19 +4,44 @@ imports silver:langutil only ast;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:concretesyntax;
+imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack as lh;
+
+imports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack as lh;
 
 imports edu:umn:cs:melt:exts:ableC:templating:abstractsyntax;
 
-marking terminal TemplateIdentifier_t /[A-Za-z_\$][A-Za-z_0-9\$]*</ lexer classes {Cidentifier};
+marking terminal TemplateIdentifier_t /[A-Za-z_\$][A-Za-z_0-9\$]*/ lexer classes {Cidentifier};
 
 function fromTemplateId
 Name ::= n::TemplateIdentifier_t
 {
-  return name(substring(0, length(n.lexeme) - 1, n.lexeme), location=n.location);
+  return name(n.lexeme, location=n.location);
 }
 
 concrete production templateDeclRefExpr_c
-top::PrimaryExpr_c ::= id::TemplateIdentifier_t params::TypeNames_c '>'
+top::PrimaryExpr_c ::= id::TemplateIdentifier_t '<' params::TypeNames_c '>'
 {
   top.ast = templateDeclRefExpr(fromTemplateId(id), params.ast, location=top.location);
+}
+
+disambiguate TemplateIdentifier_t, Identifier_t, TypeName_t
+{
+  pluck
+    case lookupBy(stringEq, lexeme, head(context)) of
+    | just(lh:templateTypenameType_c()) -> TemplateIdentifier_t
+    | just(lh:identType_c()) -> Identifier_t
+    | just(lh:typenameType_c()) -> TypeName_t
+    | nothing() -> Identifier_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for TemplateIdentifier_t, Identifier_t, TypeName_t: ${hackUnparse(it)}")
+    end;
+}
+disambiguate TemplateIdentifier_t, Identifier_t
+{
+  pluck
+    case lookupBy(stringEq, lexeme, concat(context)) of
+    | just(lh:templateIdentType_c()) -> TemplateIdentifier_t
+    | just(lh:identType_c()) -> Identifier_t
+    | nothing() -> Identifier_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for TemplateIdentifier_t, Identifier_t: ${hackUnparse(it)}")
+    end;
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/instantiationTypeExpr/Instantiation.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/instantiationTypeExpr/Instantiation.sv
@@ -4,20 +4,44 @@ imports silver:langutil only ast;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:concretesyntax;
+imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack as lh;
+
+imports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack as lh;
 
 imports edu:umn:cs:melt:exts:ableC:templating:abstractsyntax;
 
-marking terminal TemplateTypeName_t /[A-Za-z_\$][A-Za-z_0-9\$]*</ lexer classes {Cidentifier};
+marking terminal TemplateTypeName_t /[A-Za-z_\$][A-Za-z_0-9\$]*/ lexer classes {Cidentifier};
 
 function fromTemplateTypeName
 Name ::= n::TemplateTypeName_t
 {
-  return name(substring(0, length(n.lexeme) - 1, n.lexeme), location=n.location);
+  return name(n.lexeme, location=n.location);
 }
 
 concrete production templateTypedef_c
-top::TypeSpecifier_c ::= id::TemplateTypeName_t params::TypeNames_c '>'
+top::TypeSpecifier_c ::= id::TemplateTypeName_t '<' params::TypeNames_c '>'
 {
   top.realTypeSpecifiers = [templateTypedefTypeExpr(top.givenQualifiers, fromTemplateTypeName(id), params.ast)];
   top.preTypeSpecifiers = []; 
+}
+
+disambiguate TemplateTypeName_t, Identifier_t, TypeName_t
+{
+  pluck
+    case lookupBy(stringEq, lexeme, head(context)) of
+    | just(lh:templateTypenameType_c()) -> TemplateTypeName_t
+    | just(lh:identType_c()) -> Identifier_t
+    | just(lh:typenameType_c()) -> TypeName_t
+    | nothing() -> Identifier_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for TemplateTypeName_t, Identifier_t, TypeName_t: ${hackUnparse(it)}")
+    end;
+}
+disambiguate TemplateTypeName_t, TypeName_t
+{
+  pluck
+    case lookupBy(stringEq, lexeme, concat(context)) of
+    | just(lh:templateTypenameType_c()) -> TemplateTypeName_t
+    | just(lh:typenameType_c()) -> TypeName_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for TemplateTypeName_t, TypeName_t: ${hackUnparse(it)}")
+    end;
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/lexerHack/LexerHack.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/lexerHack/LexerHack.sv
@@ -1,0 +1,37 @@
+grammar edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack;
+
+imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack;
+imports edu:umn:cs:melt:ableC:abstractsyntax as ast;
+
+{-
+ - We extend the C lexer hack mechanism to include templates
+ - We need to distinguish between template identifiers, template type names,
+ - regular identifiers, and regular type names.
+ -}
+abstract production templateIdentType_c     top::IdentType ::= {}
+abstract production templateTypenameType_c  top::IdentType ::= {}
+
+global templateIdentType :: IdentType = templateIdentType_c();
+global templateTypenameType :: IdentType = templateTypenameType_c();
+
+function addTemplateIdentsToScope
+[[Pair<String IdentType>]] ::= l::[ast:Name]  context::[[Pair<String IdentType>]]
+{
+  return (map(pair(_, templateIdentType), map((.ast:name), l)) ++ head(context)) :: tail(context);
+}
+
+function addTemplateTypenamesToScope
+[[Pair<String IdentType>]] ::= l::[ast:Name]  context::[[Pair<String IdentType>]]
+{
+  return (map(pair(_, templateTypenameType), map((.ast:name), l)) ++ head(context)) :: tail(context);
+}
+
+function beginTemplateFunctionScope
+[[Pair<String IdentType>]] ::= funName::ast:Name  paramNames::Maybe<[ast:Name]>  context::[[Pair<String IdentType>]]
+{
+  return
+    addIdentsToScope(fromMaybe([], paramNames),
+      openScope(
+        addTemplateIdentsToScope([funName],
+          context)));
+}

--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/templateStructForwardDecl/Decl.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/templateStructForwardDecl/Decl.sv
@@ -4,6 +4,7 @@ imports silver:langutil;
 
 imports edu:umn:cs:melt:ableC:concretesyntax;
 imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack as lh;
+imports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack as lh;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax as ast;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction as ast;
@@ -22,5 +23,5 @@ top::ExternalDeclaration_c ::= Template_t params::TemplateParameters_c '>' Templ
 }
 action {
   context = lh:closeScope(context); -- Opened by TemplateParams_c
-  context = lh:addTypenamesToScope([ast:fromId(id)], context);
+  context = lh:addTemplateTypenamesToScope([ast:fromId(id)], context);
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/usingDecl/Decl.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templating/concretesyntax/usingDecl/Decl.sv
@@ -4,6 +4,7 @@ imports silver:langutil;
 
 imports edu:umn:cs:melt:ableC:concretesyntax;
 imports edu:umn:cs:melt:ableC:concretesyntax:lexerHack as lh;
+imports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:lexerHack as lh;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax as ast;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction as ast;
@@ -21,5 +22,5 @@ top::ExternalDeclaration_c ::= 'using' id::Identifier_t '<' params::TemplatePara
 }
 action {
   context = lh:closeScope(context); -- Opened by TemplateDecl_c
-  context = lh:addTypenamesToScope([ast:fromId(id)], context);
+  context = lh:addTemplateTypenamesToScope([ast:fromId(id)], context);
 }


### PR DESCRIPTION
This is implementing for the template extension what is described in https://github.com/melt-umn/ableC/pull/64.  That pull request should be merged before this one.  